### PR TITLE
Add a buffer that can print messages later when flushed

### DIFF
--- a/tealprint/__init__.py
+++ b/tealprint/__init__.py
@@ -1,4 +1,5 @@
 # Exported classes
+from .tealconfig import TealConfig  # lgtm[py/unused_import]
+from .teallevel import TealLevel  # lgtm[py/unused_import]
 from .tealprint import TealPrint  # lgtm[py/unused_import]
 from .tealprintbuffer import TealPrintBuffer  # lgtm[py/unused_import]
-from .teallevel import TealLevel  # lgtm[py/unused_import]

--- a/tealprint/__init__.py
+++ b/tealprint/__init__.py
@@ -1,2 +1,4 @@
 # Exported classes
-from .tealprint import TealLevel, TealPrint  # lgtm[py/unused_import]
+from .tealprint import TealPrint  # lgtm[py/unused_import]
+from .tealprintbuffer import TealPrintBuffer  # lgtm[py/unused_import]
+from .teallevel import TealLevel  # lgtm[py/unused_import]

--- a/tealprint/tealconfig.py
+++ b/tealprint/tealconfig.py
@@ -1,0 +1,6 @@
+from .teallevel import TealLevel
+
+
+class TealConfig:
+    level: TealLevel = TealLevel.info
+    _ascii: bool = False

--- a/tealprint/tealconfig.py
+++ b/tealprint/tealconfig.py
@@ -3,4 +3,3 @@ from .teallevel import TealLevel
 
 class TealConfig:
     level: TealLevel = TealLevel.info
-    _ascii: bool = False

--- a/tealprint/teallevel.py
+++ b/tealprint/teallevel.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class TealLevel(Enum):
+    none = 0  # Prints no message, not even errors
+    error = 1
+    warning = 2
+    info = 3  # Default
+    verbose = 4
+    debug = 5

--- a/tealprint/tealprint.py
+++ b/tealprint/tealprint.py
@@ -3,13 +3,11 @@ import traceback
 
 from colored import attr, fg
 
+from .tealconfig import TealConfig
 from .teallevel import TealLevel
 
 
 class TealPrint:
-    level: TealLevel = TealLevel.info
-    _ascii: bool = False
-
     @staticmethod
     def error(
         message: str,
@@ -87,14 +85,14 @@ class TealPrint:
     @staticmethod
     def _print_on_level(message: str, indent: int, color: str, level: TealLevel, exit: bool = False):
         """Prints the message if the level is equal or lower to the specified"""
-        if TealPrint.level.value >= level.value:
+        if TealConfig.level.value >= level.value:
             try:
                 if indent > 0:
                     message = "".ljust(indent * 4) + message
                 if len(color) > 0:
                     message = f"{color}{message}{attr('reset')}"
 
-                if TealPrint._ascii:
+                if TealConfig._ascii:
                     message = message.encode("utf-8", "ignore").decode("ascii", "ignore")
 
                 TealPrint._print(message)
@@ -103,7 +101,7 @@ class TealPrint:
             except UnicodeEncodeError:
                 # Some consoles can't use utf-8, encode into ascii instead, and use that
                 # in the future
-                TealPrint._ascii = True
+                TealConfig._ascii = True
                 TealPrint._print_on_level(message, indent, color, level, exit)
 
     @staticmethod

--- a/tealprint/tealprint.py
+++ b/tealprint/tealprint.py
@@ -5,9 +5,12 @@ from colored import attr, fg
 
 from .tealconfig import TealConfig
 from .teallevel import TealLevel
+from .tealprintbuffer import TealPrintBuffer
 
 
 class TealPrint:
+    _buffer = TealPrintBuffer()
+
     @staticmethod
     def error(
         message: str,
@@ -27,16 +30,8 @@ class TealPrint:
             print_exception (bool): Set to true to print an exception
             print_report_this (bool): Set to true to add an "Please report this..." message at the end
         """
-        TealPrint._print_on_level(message, indent, fg("red"), TealLevel.error)
-        if print_exception:
-            exception = traceback.format_exc()
-            TealPrint._print_on_level(exception, 0, fg("red"), TealLevel.error)
-        if print_report_this:
-            TealPrint._print_on_level(
-                "!!! Please report this and paste the above message !!!", 0, fg("red"), TealLevel.error
-            )
-        if exit:
-            sys.exit(1)
+        TealPrint._buffer.error(message, indent, exit, print_exception, print_report_this)
+        TealPrint._buffer.flush()
 
     @staticmethod
     def warning(message: str, indent: int = 0, exit: bool = False):
@@ -47,7 +42,8 @@ class TealPrint:
             indent (int): How many spaces to indent the message, indents by 4 spaces
             exit (bool): If the program should exit after printing the warning
         """
-        TealPrint._print_on_level(message, indent, fg("dark_orange"), TealLevel.warning, exit)
+        TealPrint._buffer.warning(message, indent, exit)
+        TealPrint._buffer.flush()
 
     @staticmethod
     def info(message: str, indent: int = 0, color: str = ""):
@@ -58,7 +54,8 @@ class TealPrint:
             indent (int): How many spaces to indent the message, indents by 4 spaces
             color (str): Optional color of the message
         """
-        TealPrint._print_on_level(message, indent, color, TealLevel.info)
+        TealPrint._buffer.info(message, indent, color)
+        TealPrint._buffer.flush()
 
     @staticmethod
     def verbose(message: str, indent: int = 0, color: str = ""):
@@ -69,7 +66,8 @@ class TealPrint:
             indent (int): How many spaces to indent the message, indents by 4 spaces
             color (str): Optional color of the message
         """
-        TealPrint._print_on_level(message, indent, color, TealLevel.verbose)
+        TealPrint._buffer.verbose(message, indent, color)
+        TealPrint._buffer.flush()
 
     @staticmethod
     def debug(message: str, indent: int = 0, color: str = ""):
@@ -80,31 +78,5 @@ class TealPrint:
             indent (int): How many spaces to indent the message, indents by 4 spaces
             color (str): Optional color of the message
         """
-        TealPrint._print_on_level(message, indent, color, TealLevel.debug)
-
-    @staticmethod
-    def _print_on_level(message: str, indent: int, color: str, level: TealLevel, exit: bool = False):
-        """Prints the message if the level is equal or lower to the specified"""
-        if TealConfig.level.value >= level.value:
-            try:
-                if indent > 0:
-                    message = "".ljust(indent * 4) + message
-                if len(color) > 0:
-                    message = f"{color}{message}{attr('reset')}"
-
-                if TealConfig._ascii:
-                    message = message.encode("utf-8", "ignore").decode("ascii", "ignore")
-
-                TealPrint._print(message)
-                if exit:
-                    sys.exit(1)
-            except UnicodeEncodeError:
-                # Some consoles can't use utf-8, encode into ascii instead, and use that
-                # in the future
-                TealConfig._ascii = True
-                TealPrint._print_on_level(message, indent, color, level, exit)
-
-    @staticmethod
-    def _print(message):
-        """Mostly used for mocking purposes"""
-        print(message)
+        TealPrint._buffer.debug(message, indent, color)
+        TealPrint._buffer.flush()

--- a/tealprint/tealprint.py
+++ b/tealprint/tealprint.py
@@ -1,17 +1,9 @@
 import sys
 import traceback
-from enum import Enum
 
 from colored import attr, fg
 
-
-class TealLevel(Enum):
-    none = 0  # Prints no message, not even errors
-    error = 1
-    warning = 2
-    info = 3  # Default
-    verbose = 4
-    debug = 5
+from .teallevel import TealLevel
 
 
 class TealPrint:

--- a/tealprint/tealprint_test.py
+++ b/tealprint/tealprint_test.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import pytest
 from mockito import spy2, unstub, verify, verifyZeroInteractions
 
-from .tealprint import TealLevel, TealPrint
+from . import TealConfig, TealLevel, TealPrint
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ from .tealprint import TealLevel, TealPrint
 def test_print_level(name: str, level: TealLevel, function_tuple):
     print(name)
 
-    TealPrint.level = level
+    TealConfig.level = level
 
     for function, expected in function_tuple:
         spy2(TealPrint._print)

--- a/tealprint/tealprint_test.py
+++ b/tealprint/tealprint_test.py
@@ -83,12 +83,12 @@ def test_print_level(name: str, level: TealLevel, function_tuple):
     TealConfig.level = level
 
     for function, expected in function_tuple:
-        spy2(TealPrint._print)
+        spy2(TealPrint._buffer._add_to_buffer)
 
         function("message")
 
         if expected:
-            verify(TealPrint, atleast=1)._print(...)
+            verify(TealPrint._buffer, atleast=1)._add_to_buffer(...)
         else:
             verifyZeroInteractions()
 

--- a/tealprint/tealprintbuffer.py
+++ b/tealprint/tealprintbuffer.py
@@ -1,0 +1,2 @@
+class TealPrintBuffer:
+    pass

--- a/tealprint/tealprintbuffer.py
+++ b/tealprint/tealprintbuffer.py
@@ -1,2 +1,129 @@
+import sys
+import traceback
+from io import StringIO
+
+from colored import attr, fg
+
+from . import TealConfig, TealLevel
+
+
 class TealPrintBuffer:
-    pass
+    def __init__(self) -> None:
+        self.buffer = StringIO()
+
+    def error(
+        self,
+        message: str,
+        indent: int = 0,
+        exit: bool = False,
+        print_exception: bool = False,
+        print_report_this: bool = False,
+    ) -> None:
+        """Recommendation: Only use this when an error occurs and you have to exit the program.
+           Add an error message in red to the buffer. Can print the exception.
+           If exit=True, it flushes all messages before exiting.
+           Optionally prints a "Please report this and paste the above message"
+           Call flush() to print the messages.
+
+        Args:
+            message (str): The message to print
+            indent (int): How many spaces to indent the message, indents by 4 spaces
+            exit (bool): If the program should exit after printing the error. Also flushes messages
+            print_exception (bool): Set to true to print an exception
+            print_report_this (bool): Set to true to add an "Please report this..." message at the end
+        """
+        self._add_to_buffer_on_level(message, indent, fg("red"), TealLevel.error)
+        if print_exception:
+            exception = traceback.format_exc()
+            self._add_to_buffer_on_level(exception, 0, fg("red"), TealLevel.error)
+        if print_report_this:
+            self._add_to_buffer_on_level(
+                "!!! Please report this and paste the above message !!!", 0, fg("red"), TealLevel.error
+            )
+        if exit:
+            self.flush()
+            sys.exit(1)
+
+    def warning(self, message: str, indent: int = 0, exit: bool = False) -> None:
+        """Add an orange warning message to the buffer.
+           If exit=True, it flushes all messages before exiting.
+           Call flush() to print the messages.
+
+        Args:
+            message (str): The message to print
+            indent (int): How many spaces to indent the message, indents by 4 spaces
+            exit (bool): If the program should exit after printing the warning. Also flushes messages
+        """
+        self._add_to_buffer_on_level(message, indent, fg("dark_orange"), TealLevel.warning, exit)
+
+    def info(self, message: str, indent: int = 0, color: str = "") -> None:
+        """Add a message to the buffer if TealConfig.level has been set to debug/verbose/info.
+           Call flush() to print the messages.
+
+        Args:
+            message (str): The message to print
+            indent (int): How many spaces to indent the message, indents by 4 spaces
+            color (str): Optional color of the message
+        """
+        self._add_to_buffer_on_level(message, indent, color, TealLevel.info)
+
+    def verbose(self, message: str, indent: int = 0, color: str = "") -> None:
+        """Add a message to the buffer if TealConfig.level has been set to debug/verbose.
+           Call flush() to print the messages.
+
+        Args:
+            message (str): The message to print
+            indent (int): How many spaces to indent the message, indents by 4 spaces
+            color (str): Optional color of the message
+        """
+        self._add_to_buffer_on_level(message, indent, color, TealLevel.verbose)
+
+    def debug(self, message: str, indent: int = 0, color: str = "") -> None:
+        """Add a message to the buffer if the TealConfig.level has been set to debug.
+           Call flush() to print the messages.
+
+        Args:
+            message (str): The message to print
+            indent (int): How many spaces to indent the message, indents by 4 spaces
+            color (str): Optional color of the message
+        """
+        self._add_to_buffer_on_level(message, indent, color, TealLevel.debug)
+
+    def _add_to_buffer_on_level(
+        self,
+        message: str,
+        indent: int,
+        color: str,
+        level: TealLevel,
+        exit: bool = False,
+    ) -> None:
+        """Prints the message if the level is equal or lower to the specified"""
+        if TealConfig.level.value >= level.value:
+            try:
+                if indent > 0:
+                    message = "".ljust(indent * 4) + message
+                if len(color) > 0:
+                    message = f"{color}{message}{attr('reset')}"
+
+                if TealConfig._ascii:
+                    message = message.encode("utf-8", "ignore").decode("ascii", "ignore")
+
+                self._add_to_buffer(message)
+                if exit:
+                    self.flush()
+                    sys.exit(1)
+            except UnicodeEncodeError:
+                # Some consoles can't use utf-8, encode into ascii instead, and use that
+                # in the future
+                TealConfig._ascii = True
+                self._add_to_buffer_on_level(message, indent, color, level, exit)
+
+    def _add_to_buffer(self, message: str) -> None:
+        """Mostly used for mocking purposes"""
+        self.buffer.write(message + "\n")
+
+    def flush(self) -> None:
+        """Prints the messages in the buffer"""
+        self.buffer.seek(0)
+        print(self.buffer.read())
+        self.buffer = StringIO()

--- a/tealprint/tealprintbuffer.py
+++ b/tealprint/tealprintbuffer.py
@@ -10,6 +10,7 @@ from . import TealConfig, TealLevel
 
 class TealPrintBuffer:
     _mutex = Lock()
+    _ascii: bool = False
 
     def __init__(self) -> None:
         self.buffer = StringIO()
@@ -108,7 +109,7 @@ class TealPrintBuffer:
                 if len(color) > 0:
                     message = f"{color}{message}{attr('reset')}"
 
-                if TealConfig._ascii:
+                if TealPrintBuffer._ascii:
                     message = message.encode("utf-8", "ignore").decode("ascii", "ignore")
 
                 self._add_to_buffer(message)
@@ -118,7 +119,7 @@ class TealPrintBuffer:
             except UnicodeEncodeError:
                 # Some consoles can't use utf-8, encode into ascii instead, and use that
                 # in the future
-                TealConfig._ascii = True
+                TealPrintBuffer._ascii = True
                 self._add_to_buffer_on_level(message, indent, color, level, exit)
 
     def _add_to_buffer(self, message: str) -> None:


### PR DESCRIPTION
### What changed?
- Move out `TealLevel` into it's own file
- Move out `TealPrint.level` to `TealConfig.level`
- Move printing logic to `TealPrintBuffer`
- `TealPrint` now uses an instance of `TealPrintBuffer` that flushes after each print

### Testing
- [ ] Added unit tests
- [X] Tested running `TealPrintBuffer` to make sure it works

### Safety checklist
- [ ] I have reviewed my own code

### Related Issues
Fixes #3
