### PR TITLE
Doesn't always push indent if log level is too low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2021-11-04
+
+### Fixed
+
+- When calling `TealPrint.debug("", push_indent=True)` it didn't push the indent if current level was higher.
+
 ## [0.2.0] - 2021-09-11
 
 ### Breaking Changes

--- a/tealprint/tealprintbuffer.py
+++ b/tealprint/tealprintbuffer.py
@@ -152,14 +152,15 @@ class TealPrintBuffer:
                     self.flush()
                     sys.exit(1)
 
-                if push_indent:
-                    self.push_indent(level)
-
             except UnicodeEncodeError:
                 # Some consoles can't use utf-8, encode into ascii instead, and use that
                 # in the future
                 TealPrintBuffer._ascii = True
-                self._add_to_buffer_on_level(message, push_indent, color, level, exit)
+                self._add_to_buffer_on_level(message, False, color, level, exit)
+
+        # Always push indent
+        if push_indent:
+            self.push_indent(level)
 
     def _get_indent_level(self) -> int:
         count = 0

--- a/tealprint/tealprintbuffer_test.py
+++ b/tealprint/tealprintbuffer_test.py
@@ -76,6 +76,16 @@ class T:
                 T.logger.info("test"),
             ),
         ),
+        (
+            "Always push indent when logging",
+            "Works!\n",
+            lambda: (
+                T.logger.info("Works!", push_indent=True),
+                T.logger.debug("Not shown", push_indent=True),
+                T.logger.pop_indent(),
+                T.logger.pop_indent(),
+            ),
+        ),
     ],
 )
 def test_indentation(name, expected: str, function) -> None:


### PR DESCRIPTION
Fixed calling `TealPrint.debug("", push_ident=True)` actually pushes the indent even if the current TealConfig.level is higher.

### Testing

- [X] Added unit tests

### Safety checklist

- [x] I have reviewed my own code
